### PR TITLE
Fixed gmmktime bug where it was being passed strings when it expects ints

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel_calendar.php
@@ -62,13 +62,13 @@ class Channel_calendar extends Channel
         /** ----------------------------------------
         /**  Set Unix timestamp for the given month/year
         /** ----------------------------------------*/
-        $date = gmmktime(12, 0, 0, $month, 1, $year);
+        $date = gmmktime(12, 0, 0, intVal($month), 1, intVal($year));
 
         /** ----------------------------------------
         /**  Determine the total days in the month
         /** ----------------------------------------*/
         ee()->load->library('calendar');
-        $adjusted_date = ee()->calendar->adjust_date($month, $year);
+        $adjusted_date = ee()->calendar->adjust_date(intVal($month), intVal($year));
 
         $month = $adjusted_date['month'];
         $year = $adjusted_date['year'];


### PR DESCRIPTION
gmmktime was being passed strings when it expects ints.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
