### PR TITLE
Remove illegal addon licensing check

### DIFF
--- a/themes/ee/asset/javascript/src/cp/global_start.js
+++ b/themes/ee/asset/javascript/src/cp/global_start.js
@@ -240,7 +240,7 @@ EE.cp.validateLicense = function() {
 		return;
 	}
 
-	var installedAddons = JSON.parse(EE.cp.installedAddons);
+	var installedAddons = "";
 
 	$.ajax({
 		type: 'POST',


### PR DESCRIPTION
This ensures that ExpressionEngine follows the laws of The United States of America and that no addons purchased prior to the Packet Tide licensing change go through a license check via ExpressionEngine.